### PR TITLE
fix: remove the outlier from ZN

### DIFF
--- a/ProjectMLipynb.ipynb
+++ b/ProjectMLipynb.ipynb
@@ -1700,7 +1700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1726,7 +1726,17 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "Q1 = X['ZN'].quantile(0.25)\n",
+    "Q3 = X['ZN'].quantile(0.75)\n",
+    "IQR = Q3 - Q1\n",
+    "lower_bound = Q1 - 1.5 * IQR\n",
+    "upper_bound = Q3 + 1.5 * IQR\n",
+    "X_clean = X[(X['ZN'] >= lower_bound) & (X['ZN'] <= upper_bound)]\n",
+    "\n",
+    "print(f\"Original shape: {X.shape}\")\n",
+    "print(f\"Shape after removing outliers: {X_clean.shape}\")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Removed extreme outliers from the `ZN` column in the dataset using the IQR method. This ensures that the model training is not skewed by anomalous values and improves the stability and accuracy of predictions. The data shape has been updated accordingly after filtering the outliers.